### PR TITLE
Support TypeScript + lowercase sql tag

### DIFF
--- a/after/syntax/typescript/sql.vim
+++ b/after/syntax/typescript/sql.vim
@@ -8,7 +8,7 @@ if exists('b:current_syntax')
   unlet b:current_syntax
 endif
 
-exec 'syntax include @SQLSyntax syntax/' . g:javascript_sql_dialect . '.vim'
+exec 'syntax include @SQLSyntax syntax/' . g:typescript_sql_dialect . '.vim'
 if exists('s:current_syntax')
   let b:current_syntax = s:current_syntax
 endif

--- a/after/syntax/typescript/sql.vim
+++ b/after/syntax/typescript/sql.vim
@@ -1,5 +1,5 @@
 " Vim plugin
-" Language: JavaScript
+" Language: TypeScript
 " Maintainer: Ian Langworth <ian@langworth.com>
 " Credits: Ian Langworth, Zac Collier <zacacollier@gmail.com>
 

--- a/plugin/javascript-sql.vim
+++ b/plugin/javascript-sql.vim
@@ -6,3 +6,7 @@
 if (!exists('g:javascript_sql_dialect'))
   let g:javascript_sql_dialect = 'sql'
 endif
+
+if (!exists('g:typescript_sql_dialect'))
+  let g:typescript_sql_dialect = 'sql'
+endif


### PR DESCRIPTION
- Enable syntax highlighting for the lowercase `sql` template tag
- Add syntax highlighting support for TypeScript (tested compatibility with [typescript-vim](https://github.com/leafgarland/typescript-vim))

my first time working with Vim syntax highlighting, so lmk if I can do this in a less naive way :grin: 