### PR TITLE
Make it possible to also use SQL "magic comments" to signify SQL template literals

### DIFF
--- a/after/syntax/javascript/sql.vim
+++ b/after/syntax/javascript/sql.vim
@@ -8,14 +8,16 @@ if exists('b:current_syntax')
 endif
 
 exec 'syntax include @SQLSyntax syntax/' . g:javascript_sql_dialect . '.vim'
+
 if exists('s:current_syntax')
   let b:current_syntax = s:current_syntax
 endif
 
 syntax region sqlTemplateString start=+`+ skip=+\\\(`\|$\)+ end=+`+ contains=@SQLSyntax,jsTemplateExpression,jsSpecial extend
-exec 'syntax match sqlTaggedTemplate +\%(SQL\)\%(`\)\@=+ nextgroup=sqlTemplateString'
 
-hi def link sqlTemplateString jsTemplateString
+exec 'syntax match sqlTaggedTemplate +\<sql\>\s*\ze`+ nextgroup=sqlTemplateString'
+exec 'syntax match sqlTaggedTemplate +\/\*\s*sql\s*\*\/\s*\ze`+ nextgroup=sqlTemplateString'
+
 hi def link sqlTaggedTemplate jsTaggedTemplate
 
 syn cluster jsExpression add=sqlTaggedTemplate


### PR DESCRIPTION
Thank you for sharing this plugin!

I've been using it (together with https://github.com/un-ts/prettier/tree/master/packages/sql and https://github.com/Sec-ant/prettier-plugin-embed) on a codebase that uses "magic comments" to signal that the string literal that follows is SQL. E.g:
```javascript
const query = /* sql */ `
  select
    *
  from ...
`;
```
So, I had to adapt your plugin to recognize this pattern of using block comments _in addition to_ using tags. Both continue to work with my modifications in case-insensitive manner - e.g. sql, SQL, Sql, etc all work for both block comments and tags.

I also removed `hi def link sqlTemplateString jsTemplateString` - SQL syntax highlighting looks better without it (I understand this is subjective, but maybe give it a try).

Once again, thank you for making this plugin - it made my SQL more colorful, and my day a little brighter.